### PR TITLE
fix dim err of candidate_news_vector in prediction

### DIFF
--- a/src/model/DKN/__init__.py
+++ b/src/model/DKN/__init__.py
@@ -96,11 +96,8 @@ class DKN(torch.nn.Module):
             click_probability: 0-dim tensor
         """
         # candidate_size, len(window_sizes) * num_filters
-        user_vector = torch.stack([
-            self.attention(x.unsqueeze(dim=0), clicked_news_vector.unsqueeze(dim=0))
-            for x in candidate_news_vector
-        ], dim=1).squeeze(dim=0)
-        
+        user_vector = self.attention(candidate_news_vector,
+                                     clicked_news_vector.expand(candidate_news_vector.size(0), -1, -1))
         # candidate_size
         click_probability = self.click_predictor(candidate_news_vector,
                                                  user_vector)

--- a/src/model/DKN/__init__.py
+++ b/src/model/DKN/__init__.py
@@ -96,8 +96,11 @@ class DKN(torch.nn.Module):
             click_probability: 0-dim tensor
         """
         # candidate_size, len(window_sizes) * num_filters
-        user_vector = self.attention(candidate_news_vector,
-                                     clicked_news_vector.unsqueeze(dim=0))
+        user_vector = torch.stack([
+            self.attention(x.unsqueeze(dim=0), clicked_news_vector.unsqueeze(dim=0))
+            for x in candidate_news_vector
+        ], dim=1).squeeze(dim=0)
+        
         # candidate_size
         click_probability = self.click_predictor(candidate_news_vector,
                                                  user_vector)


### PR DESCRIPTION
The candidate_news_vector passed to attention class should be [batch_size, len(window_sizes) * num_filters], but the current version has dimension [num_candidate_news, len(window_sizes) * num_filters]. In prediction mode, the batch_size should be 1 as clicked_news_vector.unsqueeze(dim=0) has done.